### PR TITLE
Custom applicationId for debug builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,6 +40,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.


### PR DESCRIPTION
**Changes**
<!-- Please summarize your changes -->
Adds an `applicationIdSuffix` for debug builds so you can install production and debug builds on the same phone.


<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
