### PR TITLE
Support nullable course description

### DIFF
--- a/lib/app/utils.dart
+++ b/lib/app/utils.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:dartx/dartx.dart';
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:schulcloud/generated/l10n.dart';
@@ -57,6 +58,9 @@ String formatFileSize(int bytes) {
 typedef L10nStringGetter = String Function(S);
 
 extension LegenWaitForItDaryString on String {
+  // ignore: unnecessary_this
+  String get blankToNull => this?.isBlank != false ? null : this;
+
   String get withoutLinebreaks => replaceAll(RegExp('[\r\n]'), '');
 
   /// Removes html tags from a string.

--- a/lib/course/data.dart
+++ b/lib/course/data.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:hive/hive.dart';
+import 'package:dartx/dartx.dart';
 import 'package:meta/meta.dart';
 import 'package:schulcloud/app/app.dart';
 import 'package:schulcloud/file/file.dart';
@@ -17,7 +18,7 @@ class Course implements Entity<Course> {
     @required this.color,
   })  : assert(id != null),
         assert(name != null),
-        assert(description != ''),
+        assert(description?.isBlank != true),
         assert(teacherIds != null),
         assert(color != null),
         lessons = LazyIds<Lesson>(
@@ -33,7 +34,7 @@ class Course implements Entity<Course> {
       : this(
           id: Id<Course>(data['_id']),
           name: data['name'],
-          description: data['description'] == '' ? null : data['description'],
+          description: (data['description'] as String).blankToNull,
           teacherIds: (data['teacherIds'] as List<dynamic>).castIds<User>(),
           color: (data['color'] as String).hexToColor,
         );

--- a/lib/course/data.dart
+++ b/lib/course/data.dart
@@ -17,6 +17,7 @@ class Course implements Entity<Course> {
     @required this.color,
   })  : assert(id != null),
         assert(name != null),
+        assert(description != ''),
         assert(teacherIds != null),
         assert(color != null),
         lessons = LazyIds<Lesson>(
@@ -32,7 +33,7 @@ class Course implements Entity<Course> {
       : this(
           id: Id<Course>(data['_id']),
           name: data['name'],
-          description: data['description'],
+          description: data['description'] == '' ? null : data['description'],
           teacherIds: (data['teacherIds'] as List<dynamic>).castIds<User>(),
           color: (data['color'] as String).hexToColor,
         );

--- a/lib/course/data.dart
+++ b/lib/course/data.dart
@@ -12,12 +12,11 @@ class Course implements Entity<Course> {
   Course({
     @required this.id,
     @required this.name,
-    @required this.description,
+    this.description,
     @required this.teacherIds,
     @required this.color,
   })  : assert(id != null),
         assert(name != null),
-        assert(description != null),
         assert(teacherIds != null),
         assert(color != null),
         lessons = LazyIds<Lesson>(

--- a/lib/course/widgets/course_detail_screen.dart
+++ b/lib/course/widgets/course_detail_screen.dart
@@ -36,16 +36,17 @@ class CourseDetailsScreen extends StatelessWidget {
           omitHorizontalPadding: true,
           sliver: SliverList(
             delegate: SliverChildListDelegate([
-              Padding(
-                padding: EdgeInsets.symmetric(
-                  vertical: 18,
-                  horizontal: 12,
+              if (course.description != null) ...[
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: FancyText(
+                    course.description,
+                    showRichText: true,
+                    emphasis: TextEmphasis.medium,
+                  ),
                 ),
-                child: Text(
-                  course.description,
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
+                SizedBox(height: 16),
+              ],
               // TODO(marcelgarus): use proper slivers when flutter_cached supports them
               _buildLessonsSliver(context, course),
             ]),


### PR DESCRIPTION
**Changes**
<!-- Please summarize your changes -->
Apparently, course descriptions can be null. We can now handle that.


<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
