### PR TITLE
Correctly dispose SignedInScreen on logout

### DIFF
--- a/lib/sign_in/utils.dart
+++ b/lib/sign_in/utils.dart
@@ -31,10 +31,10 @@ Future<bool> signOut(BuildContext context) async {
     },
   );
 
-  if (confirmed) {
-    // Actually log out.
-
-    unawaited(SchulCloudApp.navigator.pushReplacementNamed('/logout'));
+  if (confirmed == true) {
+    // There may be multiple routes in the back stack, e.g. when signing out
+    // from inside the [AccountDialog].
+    unawaited(context.rootNavigator.pushNamedAndRemoveAll('/logout'));
   }
-  return confirmed;
+  return confirmed ?? false;
 }

--- a/lib/sign_in/widgets/form.dart
+++ b/lib/sign_in/widgets/form.dart
@@ -1,3 +1,4 @@
+import 'package:black_hole_flutter/black_hole_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_svg/svg.dart';
@@ -23,15 +24,13 @@ class _SignInFormState extends State<SignInForm> {
   }
 
   void _pushSignedInPage() {
-    unawaited(SchulCloudApp.navigator
+    unawaited(context.rootNavigator
         .pushReplacementNamed(appSchemeLink('signedInScreen')));
   }
 
   Future<void> _executeSignIn(Future<void> Function() signIn) async {
     await signIn();
-
-    unawaited(SchulCloudApp.navigator
-        .pushReplacementNamed(appSchemeLink('signedInScreen')));
+    _pushSignedInPage();
   }
 
   Future<void> _signInAsDemoStudent() =>

--- a/lib/sign_in/widgets/sign_out_screen.dart
+++ b/lib/sign_in/widgets/sign_out_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:black_hole_flutter/black_hole_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:pedantic/pedantic.dart';
@@ -27,7 +28,7 @@ class _SignOutScreenState extends State<SignOutScreen> {
       // leads to the issue that logging out becomes impossible.
       unawaited(services.get<StorageService>().clear());
 
-      unawaited(SchulCloudApp.navigator.pushReplacementNamed('/login'));
+      unawaited(context.rootNavigator.pushReplacementNamed('/login'));
       logger.i('Signed out!');
     });
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: black_hole_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.3"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
 
   analyzer: ^0.39.4
-  black_hole_flutter: ^0.1.0
+  black_hole_flutter: ^0.1.3
   cupertino_icons: ^0.1.2
   dartx: ^0.2.0
   datetime_picker_formfield: ^1.0.0


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
**Closes: #183, closes: #237**

<!-- Please summarize your changes: -->
When we called `pushReplacementNamed` on sign-out, we only replaced the `AccountDialog` that was still opened. Therefore, the old `SignedInScreen` remained open, which lead to various bugs:
- #183: The old `SignedInScreen` was rebuilt after signing out, but no token was available.
- #237: Somehow, the old state was still kept. This led to `GlobalKey`s being used multiple times and also old routes being reopened even when signing in with a different account.


<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
