### PR TITLE
feat: add appbar to article screen

### DIFF
--- a/lib/news/widgets/article_screen.dart
+++ b/lib/news/widgets/article_screen.dart
@@ -29,15 +29,15 @@ class ArticleScreen extends StatelessWidget {
           body: LayoutBuilder(
             builder: (ctx, constraints) {
               final width = constraints.maxWidth;
-              final margin = width < 500 ? 0 : width * 0.08;
+              final margin = width < 500 ? 0.0 : width * 0.08;
               final padding = (width * 0.06).clamp(32.0, 64.0);
 
               return Provider<ArticleTheme>(
                 create: (_) =>
                     ArticleTheme(darkColor: Colors.purple, padding: padding),
                 child: ListView(
-                  padding: EdgeInsets.symmetric(horizontal: margin.toDouble()) +
-                      EdgeInsets.symmetric(vertical: 16),
+                  padding:
+                      EdgeInsets.symmetric(horizontal: margin, vertical: 16),
                   children: <Widget>[
                     ArticleView(article),
                   ],
@@ -50,16 +50,18 @@ class ArticleScreen extends StatelessWidget {
     );
   }
 
-  AppBar _buildAppBar(BuildContext context, Article article) => AppBar(
-        elevation: 0,
-        backgroundColor: context.theme.scaffoldBackgroundColor,
-        iconTheme: IconThemeData(color: context.theme.contrastColor),
-        actions: <Widget>[
-          SizedBox(width: 8),
-          AccountButton(),
-          SizedBox(width: 8),
-        ],
-      );
+  AppBar _buildAppBar(BuildContext context, Article article) {
+    return AppBar(
+      elevation: 0,
+      backgroundColor: context.theme.scaffoldBackgroundColor,
+      iconTheme: IconThemeData(color: context.theme.contrastColor),
+      actions: <Widget>[
+        SizedBox(width: 8),
+        AccountButton(),
+        SizedBox(width: 8),
+      ],
+    );
+  }
 }
 
 class ArticleView extends StatefulWidget {

--- a/lib/news/widgets/article_screen.dart
+++ b/lib/news/widgets/article_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:schulcloud/app/app.dart';
+import 'package:schulcloud/app/widgets/account_avatar.dart';
 
 import '../data.dart';
 import 'article_image.dart';
@@ -24,6 +25,7 @@ class ArticleScreen extends StatelessWidget {
       id: articleId,
       builder: handleLoadingError((context, article, isFetching) {
         return Scaffold(
+          appBar: _buildAppBar(context, article),
           body: LayoutBuilder(
             builder: (ctx, constraints) {
               final width = constraints.maxWidth;
@@ -34,8 +36,7 @@ class ArticleScreen extends StatelessWidget {
                 create: (_) =>
                     ArticleTheme(darkColor: Colors.purple, padding: padding),
                 child: ListView(
-                  padding: MediaQuery.of(context).padding +
-                      EdgeInsets.symmetric(horizontal: margin.toDouble()) +
+                  padding: EdgeInsets.symmetric(horizontal: margin.toDouble()) +
                       EdgeInsets.symmetric(vertical: 16),
                   children: <Widget>[
                     ArticleView(article),
@@ -48,6 +49,17 @@ class ArticleScreen extends StatelessWidget {
       }),
     );
   }
+
+  AppBar _buildAppBar(BuildContext context, Article article) => AppBar(
+        elevation: 0,
+        backgroundColor: context.theme.scaffoldBackgroundColor,
+        iconTheme: IconThemeData(color: context.theme.contrastColor),
+        actions: <Widget>[
+          SizedBox(width: 8),
+          AccountButton(),
+          SizedBox(width: 8),
+        ],
+      );
 }
 
 class ArticleView extends StatefulWidget {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
**Closes: #264 **

<!-- Please summarize your changes: -->

The `ArticleScreen` now has an `AppBar`. This should resolve the basic issue of navigation on iOS and accessing the `AccountDialog`. However, there is still room for debate if the design of the `ArticleScreen` as a whole might be updated.

<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
