### PR TITLE
Enforce stricter linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,9 +36,6 @@ linter:
     overridden_fields: true
     prefer_const_constructors: false
     prefer_constructors_over_static_methods: true
-    # Doesn't work well with the hive-generated TypeAdapters yet:
-    # https://github.com/hivedb/hive/issues/130
-    # prefer_final_locals: true
     prefer_function_declarations_over_variables: true
     prefer_int_literals: true
     prefer_interpolation_to_compose_strings: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,9 @@
-include: package:pedantic/analysis_options.yaml
+include: package:extra_pedantic/analysis_options.yaml
 
 analyzer:
+  strong-mode:
+    implicit-casts: true
+    implicit-dynamic: true
   exclude:
     - build/**
     - lib/**.g.dart
@@ -11,133 +14,40 @@ analyzer:
 # https://github.com/schul-cloud/schulcloud-flutter/issues/new
 linter:
   rules:
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
-    - annotate_overrides
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_empty_else
-    - avoid_field_initializers_in_const_classes
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_print
-    - avoid_private_typedef_functions
-    - avoid_relative_lib_imports
-    - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_slow_async_io
-    - avoid_types_as_parameter_names
-    - avoid_types_on_closure_parameters
-    - avoid_unused_constructor_parameters
-    - await_only_futures
-    - camel_case_types
-    - cancel_subscriptions
-    - cascade_invocations
-    - close_sinks
-    - comment_references
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    - file_names
-    - flutter_style_todos
-    - hash_and_equals
-    - implementation_imports
-    - invariant_booleans
-    - iterable_contains_unrelated_type
-    - join_return_with_assignment
-    - library_names
-    - library_prefixes
-    - list_remove_unrelated_type
-    - literal_only_boolean_expressions
-    - no_duplicate_case_values
-    - non_constant_identifier_names
-    - null_closures
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_final_fields
-    - prefer_final_in_for_each
+    always_put_required_named_parameters_first: false
+    avoid_bool_literals_in_conditional_expressions: true
+    avoid_classes_with_only_static_members: true
+    avoid_field_initializers_in_const_classes: true
+    avoid_function_literals_in_foreach_calls: true
+    avoid_positional_boolean_parameters: true
+    avoid_print: true
+    avoid_setters_without_getters: true
+    avoid_types_on_closure_parameters: true
+    camel_case_extensions: true
+    camel_case_types: true
+    cascade_invocations: true
+    comment_references: true
+    constant_identifier_names: true
+    flutter_style_todos: true
+    literal_only_boolean_expressions: false
+    non_constant_identifier_names: true
+    omit_local_variable_types: true
+    one_member_abstracts: true
+    overridden_fields: true
+    prefer_const_constructors: false
+    prefer_constructors_over_static_methods: true
     # Doesn't work well with the hive-generated TypeAdapters yet:
     # https://github.com/hivedb/hive/issues/130
-    # - prefer_final_locals
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_operators
-    - prefer_single_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - prefer_void_to_null
-    - provide_deprecation_message
-    - recursive_getters
-    - slash_for_doc_comments
-    - sort_child_properties_last
-    - sort_constructors_first
-    - sort_pub_dependencies
-    - sort_unnamed_constructors_first
-    - test_types_in_equals
-    # This linter rule is useful and part of the Effective Dart guidelines, but
-    # Hive doesn't conform to it yet.
-    # For more info, see https://github.com/hivedb/hive/issues/194.
-    # - type_annotate_public_apis
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    - use_full_hex_values_for_flutter_colors
-    - use_function_type_syntax_for_parameters
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - valid_regexps
-    - void_checks
+    # prefer_final_locals: true
+    prefer_function_declarations_over_variables: true
+    prefer_int_literals: true
+    prefer_interpolation_to_compose_strings: true
+    prefer_mixin: true
+    prefer_single_quotes: true
+    sort_constructors_first: true
+    type_annotate_public_apis: false
+    unnecessary_brace_in_string_interps: true
+    unnecessary_lambdas: true
+    unnecessary_statements: true
+    unnecessary_this: true
+    use_setters_to_change_properties: true

--- a/lib/app/datetime_utils.dart
+++ b/lib/app/datetime_utils.dart
@@ -2,6 +2,7 @@ import 'package:time_machine/time_machine.dart';
 import 'package:time_machine/time_machine_text_patterns.dart';
 
 extension IntInstantParser on int {
+  // ignore: use_to_and_as_if_applicable
   Instant parseInstant() => Instant.fromEpochMilliseconds(this);
 }
 

--- a/lib/app/error_reporting.dart
+++ b/lib/app/error_reporting.dart
@@ -67,7 +67,7 @@ const _loggerLevelToSentryLevel = {
 Future<void> _reportLogEvent(LogEvent event) async {
   await reportEvent(Event(
     level: _loggerLevelToSentryLevel[event.level],
-    message: event.message,
+    message: event.message?.toString(),
     exception: event.error,
     stackTrace: event.stackTrace,
     tags: {'source': 'logger'},
@@ -112,7 +112,7 @@ Future<bool> reportEvent(Event event) async {
       'platform': platformString.substring(platformString.indexOf('.') + 1),
       'flavor': services.config.name,
       if (user != null) 'schoolId': user.schoolId,
-      for (final entry in event.tags?.entries ?? {}) entry.key: entry.value,
+      for (final entry in event.tags?.entries ?? []) entry.key: entry.value,
     },
     extra: {
       'locale': window.locale.toString(),

--- a/lib/app/services/snack_bar.dart
+++ b/lib/app/services/snack_bar.dart
@@ -114,7 +114,10 @@ class SnackBarService {
         .doOnData((update) => updateMessages.add(loadingMessageBuilder(update)))
         .listen(
       (update) {},
-      onError: (e, st) async {
+      // `onError`'s `Function` doesn't have defined generic types in its
+      // declaration.
+      // ignore: avoid_types_on_closure_parameters
+      onError: (dynamic e, StackTrace st) async {
         logger.e("Multi action couldn't be performed.", e, st);
         hasError = true;
         await updateMessages.close();

--- a/lib/app/sort_filter/filtering.dart
+++ b/lib/app/sort_filter/filtering.dart
@@ -291,7 +291,7 @@ class FlagsFilter<T> extends Filter<T, Map<String, bool>> {
       filters.keys.every((k) => filters[k].apply(item, selection[k]));
 }
 
-typedef SetFlagFilterCallback<T> = void Function(String key, bool value);
+typedef SetFlagFilterCallback = void Function(String key, bool value);
 
 @immutable
 class FlagFilter<T> {
@@ -324,7 +324,7 @@ class FlagFilter<T> {
   }
 }
 
-class FlagFilterPreviewChip<T> extends StatelessWidget {
+class FlagFilterPreviewChip extends StatelessWidget {
   const FlagFilterPreviewChip({
     Key key,
     @required this.flag,
@@ -338,7 +338,7 @@ class FlagFilterPreviewChip<T> extends StatelessWidget {
         super(key: key);
 
   final String flag;
-  final SetFlagFilterCallback<T> callback;
+  final SetFlagFilterCallback callback;
   final IconData icon;
   final String label;
 

--- a/lib/app/sort_filter/sort_filter.dart
+++ b/lib/app/sort_filter/sort_filter.dart
@@ -28,7 +28,7 @@ class SortFilter<T> {
   final Map<String, Sorter<T>> sorters;
   final String defaultSorter;
   final SortOrder defaultSortOrder;
-  final Map<String, Filter> filters;
+  final Map<String, Filter<T, dynamic>> filters;
 
   SortFilterSelection<T> get defaultSelection {
     return SortFilterSelection(

--- a/lib/app/sort_filter/sorting.dart
+++ b/lib/app/sort_filter/sorting.dart
@@ -44,7 +44,7 @@ class Sorter<T> {
   Sorter.simple(
     L10nStringGetter titleGetter, {
     String webQueryKey,
-    @required Selector<T, Comparable> selector,
+    @required Selector<T, Comparable<dynamic>> selector,
   }) : this(
           titleGetter,
           webQueryKey: webQueryKey,

--- a/lib/app/utils.dart
+++ b/lib/app/utils.dart
@@ -127,6 +127,7 @@ String exceptionMessage(dynamic error) {
 }
 
 extension ImmutableMap<K, V> on Map<K, V> {
+  // ignore: use_to_and_as_if_applicable
   Map<K, V> clone() => Map.of(this);
 
   Map<K, V> copyWith(K key, V value) {
@@ -137,7 +138,7 @@ extension ImmutableMap<K, V> on Map<K, V> {
 }
 
 /// An error indicating that a permission wasn't granted by the user.
-class PermissionNotGranted<T> extends FancyException {
+class PermissionNotGranted extends FancyException {
   PermissionNotGranted()
       : super(
           isGlobal: false,

--- a/lib/app/widgets/error_widgets.dart
+++ b/lib/app/widgets/error_widgets.dart
@@ -8,8 +8,11 @@ import 'buttons.dart';
 import 'empty_state.dart';
 
 void _showStackTrace(
-    BuildContext context, dynamic error, StackTrace stackTrace) {
-  context.navigator.push(MaterialPageRoute(
+  BuildContext context,
+  dynamic error,
+  StackTrace stackTrace,
+) {
+  context.navigator.push(MaterialPageRoute<void>(
     builder: (_) {
       return Scaffold(
         appBar: AppBar(title: Text(context.s.app_error_stackTrace)),

--- a/lib/app/widgets/fade_in.dart
+++ b/lib/app/widgets/fade_in.dart
@@ -51,9 +51,9 @@ class _FadeInState extends State<FadeIn> {
   void initState() {
     super.initState();
 
-    var anchor = context.findAncestorStateOfType<_FadeInAnchorState>();
-    var visibleSince = anchor.created.add(widget.delay);
-    var now = DateTime.now();
+    final anchor = context.findAncestorStateOfType<_FadeInAnchorState>();
+    final visibleSince = anchor.created.add(widget.delay);
+    final now = DateTime.now();
 
     if (now.isAfter(visibleSince)) {
       _isVisible = true;

--- a/lib/app/widgets/schulcloud_app.dart
+++ b/lib/app/widgets/schulcloud_app.dart
@@ -146,7 +146,7 @@ class SignedInScreenState extends ReceiveShareState<SignedInScreen> {
   }
 
   Future<void> _showSnackBars() async {
-    StreamSubscription subscription;
+    StreamSubscription<SnackBarRequest> subscription;
     subscription = services.snackBar.requests.listen((request) {
       final scaffold = this.scaffold;
       if (scaffold == null) {
@@ -171,7 +171,7 @@ class _BottomTab {
         assert(title != null),
         assert(initialRoute != null);
 
-  final ValueKey key;
+  final ValueKey<String> key;
   final IconData icon;
   final L10nStringGetter title;
   final String initialRoute;
@@ -186,25 +186,25 @@ class _BottomTab {
     initialRoute: services.get<AppConfig>().webUrl('dashboard'),
   );
   static final course = _BottomTab(
-    key: ValueKey('navigation-course'),
+    key: ValueKey<String>('navigation-course'),
     icon: FontAwesomeIcons.graduationCap,
     title: (s) => s.course,
     initialRoute: services.get<AppConfig>().webUrl('courses'),
   );
   static final assignment = _BottomTab(
-    key: ValueKey('navigation-assignment'),
+    key: ValueKey<String>('navigation-assignment'),
     icon: FontAwesomeIcons.tasks,
     title: (s) => s.assignment,
     initialRoute: services.get<AppConfig>().webUrl('homework'),
   );
   static final file = _BottomTab(
-    key: ValueKey('navigation-file'),
+    key: ValueKey<String>('navigation-file'),
     icon: FontAwesomeIcons.solidFolderOpen,
     title: (s) => s.file,
     initialRoute: services.get<AppConfig>().webUrl('files'),
   );
   static final news = _BottomTab(
-    key: ValueKey('navigation-news'),
+    key: ValueKey<String>('navigation-news'),
     icon: FontAwesomeIcons.solidNewspaper,
     title: (s) => s.news,
     initialRoute: services.get<AppConfig>().webUrl('news'),

--- a/lib/app/widgets/top_level_screen_wrapper.dart
+++ b/lib/app/widgets/top_level_screen_wrapper.dart
@@ -20,7 +20,7 @@ class TopLevelScreenWrapper extends StatefulWidget {
 }
 
 class _TopLevelScreenWrapperState extends State<TopLevelScreenWrapper> {
-  StreamSubscription _deepLinksSubscription;
+  StreamSubscription<Uri> _deepLinksSubscription;
   final _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override

--- a/lib/assignment/widgets/assignments_screen.dart
+++ b/lib/assignment/widgets/assignments_screen.dart
@@ -149,7 +149,7 @@ class AssignmentCard extends StatelessWidget {
   final Assignment assignment;
   final CourseClickedCallback onCourseClicked;
   final VoidCallback onOverdueClicked;
-  final SetFlagFilterCallback<Assignment> setFlagFilterCallback;
+  final SetFlagFilterCallback setFlagFilterCallback;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/assignment/widgets/edit_submission_screen.dart
+++ b/lib/assignment/widgets/edit_submission_screen.dart
@@ -129,7 +129,7 @@ class _EditSubmissionFormState extends State<EditSubmissionForm> {
     );
   }
 
-  void _save(BuildContext context) async {
+  Future<void> _save(BuildContext context) async {
     setState(() => _isSaving = true);
     try {
       if (isNewSubmission) {

--- a/lib/calendar/data.dart
+++ b/lib/calendar/data.dart
@@ -78,7 +78,7 @@ class Event implements Entity<Event> {
     // I'm sorry this method has to be written, but the Calendar API is … not
     // the best. Recurrence rules are an array, stored in the intuitively called
     // field 'included'.
-    List<dynamic> recurrenceJson = json['included'];
+    final recurrenceJson = json['included'] as List<dynamic>;
     if (recurrenceJson == null) {
       return [];
     }

--- a/lib/calendar/widgets/dashboard_card.dart
+++ b/lib/calendar/widgets/dashboard_card.dart
@@ -16,7 +16,7 @@ class CalendarDashboardCard extends StatefulWidget {
 }
 
 class _CalendarDashboardCardState extends State<CalendarDashboardCard> {
-  StreamSubscription _subscription;
+  StreamSubscription<void> _subscription;
 
   @override
   void dispose() {
@@ -56,7 +56,7 @@ class _CalendarDashboardCardState extends State<CalendarDashboardCard> {
           // Update this widget when the current event is over.
           final nextEnd = events.map((e) => e.end).min();
           _subscription =
-              Future.delayed(Instant.now().timeUntil(nextEnd).toDuration)
+              Future<void>.delayed(Instant.now().timeUntil(nextEnd).toDuration)
                   .asStream()
                   .listen((_) => setState(() {}));
           return Column(

--- a/lib/file/service.dart
+++ b/lib/file/service.dart
@@ -74,7 +74,9 @@ class FileService {
         '$localPath.');
     final file = io.File(localPath);
 
-    final destination = await context.rootNavigator.push(MaterialPageRoute(
+    // TODO(marcelgarus): Maybe we should move the route creation to ChooseDestinationPage
+    final destination =
+        await context.rootNavigator.push(MaterialPageRoute<FilePath>(
       fullscreenDialog: true,
       builder: (_) => ChooseDestinationPage(
         title: Text(context.s.file_chooseDestination_upload),

--- a/lib/settings/widgets/preferences.dart
+++ b/lib/settings/widgets/preferences.dart
@@ -35,7 +35,7 @@ class _SwitchPreferenceState extends State<SwitchPreference> {
     );
   }
 
-  void _setValue(bool value) async {
+  Future<void> _setValue(bool value) async {
     setState(() => _isUpdating = true);
     await widget.preference.setValue(value);
     setState(() => _isUpdating = false);

--- a/lib/sign_in/widgets/sign_in_browser.dart
+++ b/lib/sign_in/widgets/sign_in_browser.dart
@@ -28,7 +28,7 @@ class SignInBrowser extends InAppBrowser {
     _trySigningIn(url);
   }
 
-  void _trySigningIn(String url) async {
+  Future<void> _trySigningIn(String url) async {
     final firstPathSegment = Uri.parse(url).pathSegments.first;
     if (firstPathSegment != 'dashboard') {
       return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -232,6 +232,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.2+4"
+  extra_pedantic:
+    dependency: "direct dev"
+    description:
+      name: extra_pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   file:
     dependency: transitive
     description:
@@ -710,7 +717,7 @@ packages:
     source: hosted
     version: "1.0.2"
   pedantic:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ dependency_overrides:
 dev_dependencies:
   build_resolvers: ^1.1.1
   build_runner: ^1.0.0
+  extra_pedantic: ^1.2.0
   flutter_driver:
     sdk: flutter
   hive_generator:
@@ -90,7 +91,6 @@ dev_dependencies:
       path: hive_generator
   intl_utils: ^1.0.2
   mockito: ^4.1.1
-  pedantic: ^1.8.0+1
   screenshots: ^2.1.1
   # We need to use a version compatible with test_api 0.2.11 required by flutter_driver.
   test: ^1.11.0

--- a/test/api/utils.dart
+++ b/test/api/utils.dart
@@ -10,7 +10,7 @@ ApiNetworkService api;
 StorageService storage;
 
 Future<void> setUpCommon() async {
-  await Future.delayed(Duration(seconds: 1));
+  await Future<void>.delayed(Duration(seconds: 1));
 
   api = ApiNetworkService();
   storage = MockStorageService();

--- a/test_driver/screenshots_test.dart
+++ b/test_driver/screenshots_test.dart
@@ -13,7 +13,7 @@ void main() {
       driver = await FlutterDriver.connect();
 
       // TODO(JonasWanke): remove when flutter driver supports async main functions, https://github.com/flutter/flutter/issues/41029
-      await Future.delayed(Duration(seconds: 10));
+      await Future<void>.delayed(Duration(seconds: 10));
     });
     tearDownAll(() async {
       await driver.close();


### PR DESCRIPTION
<!-- Please summarize your changes: -->
`implicit-casts` and `implicit-dynamic` were generating a lot of errors (≈ 170) in places where we access JSON, hence they are still disabled. I'm not sure if it's worth adding explicit casts in all of those places, though they also found some actual problems… Will probably become a separate PR though, if we decide to use them.


<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
