### PR TITLE
Handle errors better

### DIFF
--- a/lib/app/data.dart
+++ b/lib/app/data.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:characters/characters.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_cache/hive_cache.dart';
 import 'package:meta/meta.dart';

--- a/lib/app/services/network.dart
+++ b/lib/app/services/network.dart
@@ -109,6 +109,11 @@ class ForbiddenError extends ServerError {
       : super(body, (context) => context.s.app_error_forbidden);
 }
 
+class NotFoundError extends ServerError {
+  NotFoundError(ErrorBody body)
+      : super(body, (context) => context.s.app_error_notFound);
+}
+
 class ConflictError extends ServerError {
   ConflictError(ErrorBody body)
       : super(body, (context) => context.s.app_error_conflict);
@@ -280,6 +285,10 @@ class NetworkService {
 
     if (response.statusCode == HttpStatus.internalServerError) {
       throw InternalServerError(error);
+    }
+
+    if (response.statusCode == HttpStatus.notFound) {
+      throw NotFoundError(error);
     }
 
     throw UnimplementedError(

--- a/lib/app/services/network.dart
+++ b/lib/app/services/network.dart
@@ -235,7 +235,7 @@ class NetworkService {
       // The response body was not valid JSON.
       error = ErrorBody(
         name: 'Invalid response format.',
-        message: 'The server returned a response body that is not valid json.',
+        message: 'The server returned a response body that is not valid JSON.',
         code: response.statusCode,
         className: 'none',
       );

--- a/lib/app/services/network.dart
+++ b/lib/app/services/network.dart
@@ -223,7 +223,27 @@ class NetworkService {
       return response;
     }
 
-    final error = ErrorBody.fromJson(json.decode(response.body));
+    ErrorBody error;
+    try {
+      error = ErrorBody.fromJson(json.decode(response.body));
+    } on FormatException {
+      // The response body was not valid JSON.
+      error = ErrorBody(
+        name: 'Invalid response format.',
+        message: 'The server returned a response body that is not valid json.',
+        code: response.statusCode,
+        className: 'none',
+      );
+    } catch (e) {
+      // The JSON didn't contain the known error body fields.
+      error = ErrorBody(
+        name: 'Invalid error.',
+        message: "The server returned an error response that doesn't contain "
+            'the error fields we know.',
+        code: response.statusCode,
+        className: 'none',
+      );
+    }
     logger.w('Network ${response.statusCode}: $method $url', error);
 
     if (response.statusCode == HttpStatus.unauthorized) {

--- a/lib/app/utils.dart
+++ b/lib/app/utils.dart
@@ -120,12 +120,12 @@ Future<bool> tryLaunchingUrl(String url) async {
   return false;
 }
 
-// TODO(marcelgarus): remove
-String exceptionMessage(dynamic error) {
-  if (error is ServerError && error.body.message != null) {
-    return error.body.message;
+String exceptionMessage(dynamic error, BuildContext context) {
+  if (error is FancyException) {
+    return error.messageBuilder(context);
+  } else {
+    return error.toString();
   }
-  return error.toString();
 }
 
 /// An error indicating that a permission wasn't granted by the user.

--- a/lib/assignment/pages/edit_submission_page.dart
+++ b/lib/assignment/pages/edit_submission_page.dart
@@ -142,8 +142,8 @@ class _EditSubmissionFormState extends State<EditSubmissionForm> {
     } on ConflictError catch (e) {
       unawaited(services.snackBar.showMessage(e.body.message));
     } catch (e) {
-      unawaited(services.snackBar
-          .showMessage(context.s.app_error_unknown(exceptionMessage(e))));
+      unawaited(services.snackBar.showMessage(
+          context.s.app_error_unknown(exceptionMessage(e, context))));
     } finally {
       setState(() => _isSaving = false);
     }

--- a/lib/course/widgets/course_card.dart
+++ b/lib/course/widgets/course_card.dart
@@ -21,16 +21,29 @@ class CourseCard extends StatelessWidget {
           Expanded(
             child: EntityListBuilder<User>(
               ids: course.teacherIds,
-              builder: handleError((_, teachers, __) {
+              builder: (_, snapshot, __) {
+                String text;
+                if (snapshot != null) {
+                  if (snapshot.hasError) {
+                    final error = snapshot.error;
+                    if (error is FancyException) {
+                      text = error.messageBuilder(context);
+                    } else {
+                      text = snapshot.error.toString();
+                    }
+                  } else if (snapshot.hasData) {
+                    text = snapshot.data
+                        .where((teacher) => teacher != null)
+                        .map((teacher) => teacher.shortName)
+                        .join(', ');
+                  }
+                }
                 return FancyText(
-                  teachers
-                      ?.where((teacher) => teacher != null)
-                      ?.map((teacher) => teacher.shortName)
-                      ?.join(', '),
+                  text,
                   maxLines: 1,
                   emphasis: TextEmphasis.medium,
                 );
-              }),
+              },
             ),
           ),
         ],

--- a/lib/course/widgets/course_card.dart
+++ b/lib/course/widgets/course_card.dart
@@ -33,7 +33,7 @@ class CourseCard extends StatelessWidget {
                     }
                   } else if (snapshot.hasData) {
                     text = snapshot.data
-                        .where((teacher) => teacher != null)
+                        .whereNotNull()
                         .map((teacher) => teacher.shortName)
                         .join(', ');
                   }

--- a/lib/course/widgets/course_card.dart
+++ b/lib/course/widgets/course_card.dart
@@ -25,12 +25,7 @@ class CourseCard extends StatelessWidget {
                 String text;
                 if (snapshot != null) {
                   if (snapshot.hasError) {
-                    final error = snapshot.error;
-                    if (error is FancyException) {
-                      text = error.messageBuilder(context);
-                    } else {
-                      text = snapshot.error.toString();
-                    }
+                    text = exceptionMessage(snapshot.error, context);
                   } else if (snapshot.hasData) {
                     text = snapshot.data
                         .where((teacher) => teacher != null)

--- a/lib/file/widgets/upload_fab.dart
+++ b/lib/file/widgets/upload_fab.dart
@@ -14,7 +14,11 @@ class UploadFab extends StatelessWidget {
   Widget build(BuildContext context) {
     return EntityBuilder<User>(
       id: services.storage.userId,
-      builder: handleError((context, user, _) {
+      builder: (context, snapshot, _) {
+        if (snapshot == null || !snapshot.hasData) {
+          return SizedBox();
+        }
+        final user = snapshot.data;
         if (user == null || !user.hasPermission(Permission.fileStorageCreate)) {
           return SizedBox();
         }
@@ -29,7 +33,7 @@ class UploadFab extends StatelessWidget {
           },
           child: Icon(Icons.file_upload),
         );
-      }),
+      },
     );
   }
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -6,6 +6,7 @@
   "app_demo_explanation": "Dies ist ein Demo-Account. Sämtliche Aktionen, die Daten anlegen oder ändern, sind deaktiviert und nicht sichtbar.",
   "app_emptyState_retry": "Nochmal versuchen",
   "app_error_badRequest": "Der Server versteht uns nicht. Gibt es vielleicht ein Update für die App?",
+  "app_error_notFound": "Diese Ressource konnte nicht gefunden werden.",
   "app_error_conflict": "Deine Änderungen können nicht gespeichert werden, weil jemand anderes zur selben Zeit etwas geändert hat.",
   "app_error_forbidden": "Du hast keine Berechtigung dazu.",
   "app_error_internal": "Ein unbekannter Serverfehler ist aufgetreten.",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -6,6 +6,7 @@
   "app_demo_explanation": "This is a demo account. All actions that create or change data are deactivated and not visible.",
   "app_emptyState_retry": "Try again",
   "app_error_badRequest": "The server doesn't understand us. Maybe there's an update available for the app?",
+  "app_error_notFound": "Couldn't find this resource.",
   "app_error_conflict": "Your changes conflict with changes someone else did at the same time.",
   "app_error_forbidden": "You don't have the permission to do that.",
   "app_error_internal": "An unknown server error occurred.",


### PR DESCRIPTION
There is now a new `NotFoundError`.
Also, errors on the course screen are more beautiful (no invasion of giant broken pens anymore) and the UploadFab gets hidden if an error occurs.

**Screenshots**

| `NotFoundError`  | errors on the course screen  | UploadFab hidden if error occurs |
| :------------: | :------------: | :--: |
| ![image](https://user-images.githubusercontent.com/8601189/90314207-506dcd00-df12-11ea-814b-9bc4cb26eebb.png) | ![image](https://user-images.githubusercontent.com/8601189/90314212-5b286200-df12-11ea-8802-09d40b0366df.png) | ![image](https://user-images.githubusercontent.com/8601189/90314217-5fed1600-df12-11ea-8732-f693c62d1b34.png) |
