### PR TITLE
Update share plugin to support Android embedding v2

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         <meta-data android:name="flutterEmbedding" android:value="2" />
 
         <activity
-            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:name="io.flutter.plugins.share.FlutterShareReceiverActivity"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -858,8 +858,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "1f8b139"
-      resolved-ref: "1f8b139ca0bd35b643ef4f5ccce3a1b09931f16a"
+      ref: "998cced"
+      resolved-ref: "998cced039b27f5cc0e19ef30e744b91578a31b0"
       url: "https://github.com/d-silveira/flutter-share.git"
     source: git
     version: "0.6.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   share:
     git:
       url: https://github.com/d-silveira/flutter-share.git
-      ref: 1f8b139
+      ref: 998cced
   swipeable_page_route: ^0.1.3
   streaming_shared_preferences: ^1.0.1
   system_info: ^0.1.3


### PR DESCRIPTION
<!-- Please summarize your changes: -->
This fixes the `MissingPluginException` we got from the share plugin.


<!-- Add this section if you need it.
**Screenshots**

| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
